### PR TITLE
fixed a spelling mistake of the logo file name

### DIFF
--- a/app/views/common/_header.html.erb
+++ b/app/views/common/_header.html.erb
@@ -1,7 +1,7 @@
 <div class="header">
     <div class="header__contents">
         <div class="header__contents__logo">
-            <%= image_tag '/assets/mini-blog-logo_paleturquoisegit.png', width: "375px", height: "90px" %>
+            <%= image_tag "mini-blog-logo_paleturquoise.png", width: "375px", height: "90px" %>
         </div>
         <ul class="nav">
             <li class="signin">Sign in</li>


### PR DESCRIPTION
## What
- 変更したロゴが表示されていなかったので表示させた(ファイル名のスペルミス)

## Why
ロゴはサイトにおいて一番大事なので、後回しにするのではなく常に表示されるようにしたかったから。

<img width="1440" alt="スクリーンショット 2020-11-08 17 57 49" src="https://user-images.githubusercontent.com/26789049/98460944-ecdefd00-21eb-11eb-98de-584a220af09e.png">