### PR TITLE
投稿&編集フォームのデザイン修正

### DIFF
--- a/app/assets/stylesheets/tweets.scss
+++ b/app/assets/stylesheets/tweets.scss
@@ -1,3 +1,17 @@
+input, button, textarea, select {
+    margin: 0;
+    padding: 0;
+    background: none;
+    border: none;
+    border-radius: 0;
+    outline: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-sizing: border-box;
+    display: block;
+  }
+
 .wrapper{
     height: 100vh;
     width: 100vw;
@@ -29,6 +43,43 @@
                 color: saddlebrown;
             }
 
+        }
+
+        &__form{
+            padding: 5px 10px;
+            margin-bottom: 40px;
+
+            h3{
+                margin-top: 0px;
+                color: #41a0a0;
+            }
+            input[type="text"] {
+                width: 100%;
+                height: 30px;
+                padding: 5px 10px;
+                background-color: white;
+                border: dotted 2px #41a0a0;
+                border-radius: 5px;
+            }
+
+            textarea{
+                width: 100%;
+                height: 150px;
+                padding: 5px 10px;
+                background-color: white;
+                border: dotted 2px #41a0a0;
+                border-radius: 5px;
+            }
+
+            input[type="submit"]{
+                width: 100%;
+                height: 35px;
+                background-color: #41a0a0;
+                color: white;
+                font-weight: bold;
+                border-style: none;
+                border-radius: 5px;
+            }
         }
 
         &__post{

--- a/app/views/tweets/edit.html.erb
+++ b/app/views/tweets/edit.html.erb
@@ -1,9 +1,20 @@
 <div class="wrapper">
     <div class="contents">
         <%= form_for(@tweet, method: :patch) do |f|%>
-            <%= f.text_field :title, placeholder: "Title" %>
-            <%= f.text_area :text, placeholder: "Text" %>
-            <%= f.submit "Post" %>
+
+            <div class="contents__form">
+                <h3><%= f.label :title, '投稿タイトル' %></h3>
+                <%= f.text_field :title, placeholder: "Title" %>
+            </div>
+
+            <div class="contents__form">
+                <h3><%= f.label :text, '投稿内容' %></h3>
+                <%= f.text_area :text, placeholder: "Text" %>
+            </div>
+            <div class="contents__form">
+                <%= f.submit "Save" %>
+            </div>
+
         <% end %>
     </div>
 </div>

--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -1,9 +1,20 @@
 <div class="wrapper">
     <div class="contents">
         <%= form_for(@tweet) do |f|%>
-            <%= f.text_field :title, placeholder: "Title", value: "" %>
-            <%= f.text_area :text, placeholder: "Text" %>
-            <%= f.submit "Post" %>
+
+            <div class="contents__form">
+                <h3><%= f.label :title, '投稿タイトル' %></h3>
+                <%= f.text_field :title, placeholder: "Title", value: "" %>
+            </div>
+
+            <div class="contents__form">
+                <h3><%= f.label :text, '投稿内容' %></h3>
+                <%= f.text_area :text, placeholder: "Text" %>
+            </div>
+            <div class="contents__form">
+                <%= f.submit "Post" %>
+            </div>
+
         <% end %>
     </div>
 </div>


### PR DESCRIPTION
## WHAT
- フォームデザインのリセット&新しいデザインの適用@tweets.scss
- new&editのhtmlの変更

## WHY
見た目を整えるため

<img width="1440" alt="スクリーンショット 2021-03-10 22 02 46" src="https://user-images.githubusercontent.com/26789049/110633641-5ac42100-81ec-11eb-8381-75c720b5d2c0.png">

<img width="1440" alt="スクリーンショット 2021-03-10 22 03 00" src="https://user-images.githubusercontent.com/26789049/110633664-6283c580-81ec-11eb-8d63-3a29f46306fa.png">
