### PR TITLE
投稿＆編集フォームのデザイン修正(入力内容をまとめた)

### DIFF
--- a/app/assets/stylesheets/tweets.scss
+++ b/app/assets/stylesheets/tweets.scss
@@ -36,6 +36,12 @@ input, button, textarea, select {
         margin-left: 15vw;
         margin-right: 15vw;
         
+        form {
+            width: 70vw;
+            background-color: white;
+            border-radius: 5px;
+        }
+
         &__nickname{
             margin-bottom: 20px;
 
@@ -46,39 +52,47 @@ input, button, textarea, select {
         }
 
         &__form{
-            padding: 5px 10px;
-            margin-bottom: 40px;
+            width: 80%;
+            padding-top: 40px;
+            padding-bottom: 5px;
+            margin: 0 auto;
 
-            h3{
-                margin-top: 0px;
-                color: #41a0a0;
-            }
-            input[type="text"] {
-                width: 100%;
-                height: 30px;
+            &__box{
                 padding: 5px 10px;
-                background-color: white;
-                border: dotted 2px #41a0a0;
-                border-radius: 5px;
-            }
+                margin-bottom: 40px;
 
-            textarea{
-                width: 100%;
-                height: 150px;
-                padding: 5px 10px;
-                background-color: white;
-                border: dotted 2px #41a0a0;
-                border-radius: 5px;
-            }
+                h3{
+                    margin-top: 0px;
+                    color: #41a0a0;
+                    text-align: center;
+                }
+                input[type="text"] {
+                    width: 100%;
+                    height: 30px;
+                    padding: 5px 10px;
+                    background-color: white;
+                    border: dotted 2px #41a0a0;
+                    border-radius: 5px;
+                }
 
-            input[type="submit"]{
-                width: 100%;
-                height: 35px;
-                background-color: #41a0a0;
-                color: white;
-                font-weight: bold;
-                border-style: none;
-                border-radius: 5px;
+                textarea{
+                    width: 100%;
+                    height: 150px;
+                    padding: 5px 10px;
+                    background-color: white;
+                    border: dotted 2px #41a0a0;
+                    border-radius: 5px;
+                }
+
+                input[type="submit"]{
+                    width: 100%;
+                    height: 35px;
+                    background-color: #41a0a0;
+                    color: white;
+                    font-weight: bold;
+                    border-style: none;
+                    border-radius: 5px;
+                }
             }
         }
 

--- a/app/views/tweets/edit.html.erb
+++ b/app/views/tweets/edit.html.erb
@@ -3,16 +3,20 @@
         <%= form_for(@tweet, method: :patch) do |f|%>
 
             <div class="contents__form">
-                <h3><%= f.label :title, '投稿タイトル' %></h3>
-                <%= f.text_field :title, placeholder: "Title" %>
-            </div>
 
-            <div class="contents__form">
-                <h3><%= f.label :text, '投稿内容' %></h3>
-                <%= f.text_area :text, placeholder: "Text" %>
-            </div>
-            <div class="contents__form">
-                <%= f.submit "Save" %>
+                <div class="contents__form__box">
+                    <h3><%= f.label :title, '投稿タイトル' %></h3>
+                    <%= f.text_field :title, placeholder: "Title" %>
+                </div>
+
+                <div class="contents__form__box">
+                    <h3><%= f.label :text, '投稿内容' %></h3>
+                    <%= f.text_area :text, placeholder: "Text" %>
+                </div>
+                <div class="contents__form__box">
+                    <%= f.submit "Save" %>
+                </div>
+
             </div>
 
         <% end %>

--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -3,16 +3,20 @@
         <%= form_for(@tweet) do |f|%>
 
             <div class="contents__form">
-                <h3><%= f.label :title, '投稿タイトル' %></h3>
-                <%= f.text_field :title, placeholder: "Title", value: "" %>
-            </div>
+            
+                <div class="contents__form__box">
+                    <h3><%= f.label :title, '投稿タイトル' %></h3>
+                    <%= f.text_field :title, placeholder: "Title", value: "" %>
+                </div>
 
-            <div class="contents__form">
-                <h3><%= f.label :text, '投稿内容' %></h3>
-                <%= f.text_area :text, placeholder: "Text" %>
-            </div>
-            <div class="contents__form">
-                <%= f.submit "Post" %>
+                <div class="contents__form__box">
+                    <h3><%= f.label :text, '投稿内容' %></h3>
+                    <%= f.text_area :text, placeholder: "Text" %>
+                </div>
+                <div class="contents__form__box">
+                    <%= f.submit "Post" %>
+                </div>
+
             </div>
 
         <% end %>


### PR DESCRIPTION
## WHAT
- contents__formクラスをcontents__form__boxに変更
- contents__form__boxをまとめてcontents__form内に格納
- contents__form__boxの大きさ縮小&中央寄せ

## WHY
sign in&upのフォームでも回して使えるようにするため。

<img width="1440" alt="スクリーンショット 2021-03-20 14 24 02" src="https://user-images.githubusercontent.com/26789049/111859979-ed508700-8987-11eb-8ae3-ad4b88bf8f32.png">

<img width="1440" alt="スクリーンショット 2021-03-20 14 24 17" src="https://user-images.githubusercontent.com/26789049/111859983-f6415880-8987-11eb-959b-0d0665d5cdb2.png">

