### PR TITLE
sign in&upフォームデザインの修正

### DIFF
--- a/app/assets/stylesheets/tweets.scss
+++ b/app/assets/stylesheets/tweets.scss
@@ -57,15 +57,100 @@ input, button, textarea, select {
             padding-bottom: 5px;
             margin: 0 auto;
 
+            h1{
+                margin-top: 0px;
+                margin-bottom: 40px;
+                color: #5e5e5e;
+                text-align: center;
+            }
+
             &__box{
                 padding: 5px 10px;
                 margin-bottom: 40px;
+                text-align: center;
 
                 h3{
                     margin-top: 0px;
                     color: #41a0a0;
-                    text-align: center;
                 }
+
+                input[type="email"] {
+                    width: 100%;
+                    height: 30px;
+                    padding: 5px 10px;
+                    background-color: white;
+                    border: dotted 2px #41a0a0;
+                    border-radius: 5px;
+                }
+
+                input[type="password"] {
+                    width: 100%;
+                    height: 30px;
+                    padding: 5px 10px;
+                    background-color: white;
+                    border: dotted 2px #41a0a0;
+                    border-radius: 5px;
+                }
+
+                input[type="checkbox"]{
+                    display: none;
+                }
+                /* チェックボックスの代わりを成すラベル */
+                input[type="checkbox"]+label{
+                    display: none;
+                    cursor: pointer;
+                    display: inline-block;
+                    position: relative;
+                    padding-left: 25px;
+                    padding-right: 10px;
+                }
+                /* ラベルの左に表示させる四角形のボックス□ */
+                input[type="checkbox"]+label::before{
+                    content: "";
+                    position: absolute;
+                    display: block;
+                    box-sizing: border-box;
+                    width: 20px;
+                    height: 20px;
+                    margin-top: -10px;
+                    left: 0;
+                    top: 50%;
+                    border: dotted 2px #41a0a0;
+                    border-radius: 5px;
+                    background-color: #FFF; /* 背景の色変更 お好きな色を */
+                }
+                /* チェックが入った時のレ点 */
+                input[type="checkbox"]:checked+label::after{
+                    content: "";
+                    position: absolute;
+                    display: block;
+                    box-sizing: border-box;
+                    width: 18px;
+                    height: 9px;
+                    margin-top: -9px;
+                    top: 50%;
+                    left: 3px;
+                    transform: rotate(-45deg);
+                    border-bottom: 3px solid;
+                    border-left: 3px solid;
+                    border-color:  #585753; /* チェックの色変更 お好きな色を */
+                }
+
+                .actions input[type="submit"]{
+                    width: 100%;
+                    height: 35px;
+                    background-color: #41a0a0;
+                    color: white;
+                    font-weight: bold;
+                    border-style: none;
+                    border-radius: 5px;
+                }
+
+                a {
+                    text-decoration: none;
+                    color: #41a0a0;
+                }
+
                 input[type="text"] {
                     width: 100%;
                     height: 30px;
@@ -165,6 +250,9 @@ input, button, textarea, select {
                 }
             }
 
+        }
+        .footer {
+            height: 40px;
         }
     }
 }

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,38 +1,51 @@
 <div class="wrapper">
 <div class="contents">
-  <h2>Sign up</h2>
 
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
 
-    <div class="field">
-      <%= f.label :nickname %> <em>(10 characters maximum)</em><br />
-      <%= f.text_field :nickname, autofocus: true, maxlength: "10" %>
+    <div class="contents__form">
+
+      <h1>Sign Up</h1>
+    
+      <div class="contents__form__box">
+        <h3><%= f.label :nickname %> <em>(10 characters maximum)</em></h3>
+        <%= f.text_field :nickname, autofocus: true, maxlength: "10" %>
+      </div>
+
+      <div class="contents__form__box">
+        <h3><%= f.label :email %></h3>
+        <%= f.email_field :email %>
+      </div>
+
+      <div class="contents__form__box">
+        <h3><%= f.label :password %></h3>
+        <% if @validatable %>
+        <em>(<%= @minimum_password_length %> characters minimum)</em>
+        <% end %><br />
+        <%= f.password_field :password, autocomplete: "new-password" %>
+      </div>
+
+      <div class="contents__form__box">
+        <h3><%= f.label :password_confirmation %></h3>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+      </div>
+
+      <div class="contents__form__box">
+        <div class="actions">
+          <%= f.submit "Sign up" %>
+        </div>
+      </div>
+
+      <div class="contents__form__box">
+        <%= render "devise/shared/links" %>
+      </div>
+
     </div>
 
-    <div class="field">
-      <%= f.label :email %><br />
-      <%= f.email_field :email %>
-    </div>
-
-    <div class="field">
-      <%= f.label :password %>
-      <% if @validatable %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em>
-      <% end %><br />
-      <%= f.password_field :password, autocomplete: "new-password" %>
-    </div>
-
-    <div class="field">
-      <%= f.label :password_confirmation %><br />
-      <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-    </div>
-
-    <div class="actions">
-      <%= f.submit "Sign up" %>
-    </div>
   <% end %>
 
-  <%= render "devise/shared/links" %>
+  <div class="footer"></div>
+
 </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,30 +1,42 @@
 <div class="wrapper">
 <div class="contents">
-  <h2>Sign in</h2>
 
   <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-    <div class="field">
-      <%= f.label :email %><br />
-      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-    </div>
 
-    <div class="field">
-      <%= f.label :password %><br />
-      <%= f.password_field :password, autocomplete: "current-password" %>
-    </div>
+    <div class="contents__form">
 
-    <% if devise_mapping.rememberable? %>
-      <div class="field">
-        <%= f.label :remember_me %>
-        <%= f.check_box :remember_me %>
+      <h1>Sign In</h1>
+
+      <div class="contents__form__box">
+        <h3><%= f.label :email %></h3>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
       </div>
-    <% end %>
 
-    <div class="actions">
-      <%= f.submit "Log in" %>
+      <div class="contents__form__box">
+        <h3><%= f.label :password %></h3>
+        <%= f.password_field :password, autocomplete: "current-password" %>
+      </div>
+
+      <% if devise_mapping.rememberable? %>
+        <div class="contents__form__box">
+          <%= f.check_box :remember_me %>
+          <%= f.label :remember_me %>
+        </div>
+      <% end %>
+
+      <div class="contents__form__box">
+        <div class="actions">
+          <%= f.submit "Log in" %>
+        </div>
+      </div>
+
+      <div class="contents__form__box">
+        <%= render "devise/shared/links" %>
+      </div>
+
     </div>
   <% end %>
+  <div class="footer"></div>
 
-  <%= render "devise/shared/links" %>
 </div>
 </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -3,11 +3,11 @@
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "Create an account", new_registration_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "Forgot password?", new_password_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/tweets/edit.html.erb
+++ b/app/views/tweets/edit.html.erb
@@ -20,5 +20,6 @@
             </div>
 
         <% end %>
+        <div class="footer"></div>
     </div>
 </div>

--- a/app/views/tweets/index.html.erb
+++ b/app/views/tweets/index.html.erb
@@ -27,5 +27,7 @@
             </div>
         <% end %>
         <%= paginate @tweets %>
+
+        <div class="footer"></div>
     </div>
 </div>

--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -20,5 +20,6 @@
             </div>
 
         <% end %>
+        <div class="footer"></div>
     </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -28,5 +28,6 @@
             </div>
         <% end %>
         <%= paginate @tweets %>
+        <div class="footer"></div>
     </div>
 </div>


### PR DESCRIPTION
## WHAT
- registrationsとsessionsのnewのフォームデザインを修正
- 全体に空のfooterクラスを用意(sign upのフォームの下に余白を作るため)

## WHY
フォームデザインを投稿フォームと揃えるため。

<img width="1440" alt="スクリーンショット 2021-03-20 18 39 35" src="https://user-images.githubusercontent.com/26789049/111865653-9fe61100-89ab-11eb-9e99-2996719f39aa.png">

<img width="1440" alt="スクリーンショット 2021-03-20 18 39 49" src="https://user-images.githubusercontent.com/26789049/111865662-a83e4c00-89ab-11eb-95c3-770c748d2622.png">

<img width="1440" alt="スクリーンショット 2021-03-20 18 40 03" src="https://user-images.githubusercontent.com/26789049/111865670-b0968700-89ab-11eb-9798-7b7145b4555b.png">


